### PR TITLE
Fix #6 Incorrect revertTransaction amount parameter name leads always to full refunds

### DIFF
--- a/MaibDescription.php
+++ b/MaibDescription.php
@@ -210,7 +210,7 @@ class MaibDescription extends Description {
 							'location' => 'postField',
 							'required' => true,
 						],
-						'amount '  => [
+						'amount'   => [
 							'type'     => 'string',
 							'location' => 'postField',
 							'required' => false,


### PR DESCRIPTION
Removed extra space in `amount` parameter for `revertTransaction` operation