### PR TITLE
Fix #9 Incorrect revertTransaction amount value

### DIFF
--- a/MaibClient.php
+++ b/MaibClient.php
@@ -217,7 +217,7 @@ class MaibClient extends GuzzleClient
 		$args = array(
 			'command'  => 'r',
 			'trans_id' => $transId,
-			'amount' => $amount,
+			'amount' => (string)($amount * 100),
 		);
 
 		return parent::revertTransaction($args);


### PR DESCRIPTION
Amount value must be integer, multiplied by 100 to avoid any fractional values according to the MAIB API specifications.